### PR TITLE
Making this hook easier to use

### DIFF
--- a/.github/workflows/release_chart.yml
+++ b/.github/workflows/release_chart.yml
@@ -1,0 +1,27 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.0
+        with:
+          charts_dir: deploy
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ spec:
             solverName: dynu
             config:
               secretName: dynu-secret # Adjust this in case you changed the secretName
-              zoneName: <YOUR_DOMAIN> # Add the domain which you want to create certiciates for
 ```
 
 ## Certificate
@@ -93,44 +92,34 @@ see [webhook-example](https://github.com/cert-manager/webhook-example)
 
 If you want to run the test
 - update testdata/dynu-secret with the correct Dynu API key (base64).
-- update testdata/config.json with the your domain name (zoneName)
 
 ```bash
 TEST_ZONE_NAME=your.domain.name. make test
 go test -v .
 === RUN   TestRunsSuite
-    fixture.go:117: started apiserver on "http://127.0.0.1:36591"
-=== RUN   TestRunsSuite/Conformance
-=== RUN   TestRunsSuite/Conformance/Basic
-=== RUN   TestRunsSuite/Conformance/Basic/PresentRecord
-I0217 17:23:26.141761  750764 request.go:1097] Request Body: {"kind":"Namespace","apiVersion":"v1","metadata":{"name":"basic-present-record","creationTimestamp":null},"spec":{},"status":{}}
-I0217 17:23:26.141879  750764 round_trippers.go:423] curl -k -v -XPOST  -H "User-Agent: cert-manager-webhook-dynu.test/v0.0.0 (linux/amd64) kubernetes/$Format" -H "Accept: application/json, */*" -H "Content-Type: application/json" 'http://127.0.0.1:36591/api/v1/namespaces'
-I0217 17:23:26.143894  750764 round_trippers.go:443] POST http://127.0.0.1:36591/api/v1/namespaces 201 Created in 1 milliseconds
-I0217 17:23:26.143918  750764 round_trippers.go:449] Response Headers:
-I0217 17:23:26.143925  750764 round_trippers.go:452]     Content-Type: application/json
-I0217 17:23:26.143930  750764 round_trippers.go:452]     Date: Thu, 17 Feb 2022 16:23:26 GMT
-I0217 17:23:26.143935  750764 round_trippers.go:452]     Content-Length: 311
-I0217 17:23:26.143940  750764 round_trippers.go:452]     Cache-Control: no-cache, private
-I0217 17:23:26.143993  750764 request.go:1097] Response Body: {"kind":"Namespace","apiVersion":"v1","metadata":{"name":"basic-present-record","selfLink":"/api/v1/namespaces/basic-present-record","uid":"41f5aa15-2d84-43bd-ab3b-779de179fd05","resourceVersion":"45","creationTimestamp":"2022-02-17T16:23:26Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}
-...
-I0217 17:23:44.233823  750764 request.go:1097] Request Body: {"kind":"DeleteOptions","apiVersion":"v1"}
-I0217 17:23:44.233884  750764 round_trippers.go:423] curl -k -v -XDELETE  -H "User-Agent: cert-manager-webhook-dynu.test/v0.0.0 (linux/amd64) kubernetes/$Format" -H "Accept: application/json, */*" -H "Content-Type: application/json" 'http://127.0.0.1:36591/api/v1/namespaces/basic-present-record'
-I0217 17:23:44.235897  750764 round_trippers.go:443] DELETE http://127.0.0.1:36591/api/v1/namespaces/basic-present-record 200 OK in 1 milliseconds
-I0217 17:23:44.235912  750764 round_trippers.go:449] Response Headers:
-I0217 17:23:44.235920  750764 round_trippers.go:452]     Cache-Control: no-cache, private
-I0217 17:23:44.235925  750764 round_trippers.go:452]     Content-Type: application/json
-I0217 17:23:44.235932  750764 round_trippers.go:452]     Date: Thu, 17 Feb 2022 16:23:44 GMT
-I0217 17:23:44.235938  750764 round_trippers.go:452]     Content-Length: 359
-I0217 17:23:44.235967  750764 request.go:1097] Response Body: {"kind":"Namespace","apiVersion":"v1","metadata":{"name":"basic-present-record","selfLink":"/api/v1/namespaces/basic-present-record","uid":"41f5aa15-2d84-43bd-ab3b-779de179fd05","resourceVersion":"48","creationTimestamp":"2022-02-17T16:23:26Z","deletionTimestamp":"2022-02-17T16:23:44Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Terminating"}}
-=== RUN   TestRunsSuite/Conformance/Extended
-=== RUN   TestRunsSuite/Conformance/Extended/DeletingOneRecordRetainsOthers
-    suite.go:73: skipping test as strict mode is disabled, see: https://github.com/jetstack/cert-manager/pull/1354
---- PASS: TestRunsSuite (24.78s)
-    --- PASS: TestRunsSuite/Conformance (18.09s)
-        --- PASS: TestRunsSuite/Conformance/Basic (18.09s)
-            --- PASS: TestRunsSuite/Conformance/Basic/PresentRecord (18.09s)
-        --- PASS: TestRunsSuite/Conformance/Extended (0.00s)
-            --- SKIP: TestRunsSuite/Conformance/Extended/DeletingOneRecordRetainsOthers (0.00s)
+=== RUN   TestRunsSuite/Basic
+=== RUN   TestRunsSuite/Basic/PresentRecord
+    util.go:68: created fixture "basic-present-record"
+    suite.go:37: Calling Present with ChallengeRequest: &v1alpha1.ChallengeRequest{UID:"", Action:"", Type:"", DNSName:"example.com", Key:"123d==", ResourceNamespace:"basic-present-record", ResolvedFQDN:"cert-manager-dns01-tests.your.domain.name.", ResolvedZone:"your.domain.name.", AllowAmbientCredentials:false, Config:(*v1.JSON)(0x40004e3398)}
+I0801 22:23:32.050846   29444 main.go:113] call function Present: ResourceNamespace=basic-present-record, ResolvedZone=your.domain.name., ResolvedFQDN=cert-manager-dns01-tests.your.domain.name. DNSName=example.com
+I0801 22:23:32.064490   29444 main.go:119] Decoded configuration {dynu-secret}
+I0801 22:23:52.811140   29444 main.go:284] Added TXT record result: {"statusCode":200,"id":8718493,"domainId":9754501,"domainName":"your.domain.name","nodeName":"cert-manager-dns01-tests","hostname":"cert-manager-dns01-tests.your.domain.name","recordType":"TXT","ttl":60,"state":true,"content":"cert-manager-dns01-tests.your.domain.name. 60 IN TXT \"123d==\"","updatedOn":"2022-08-02T05:23:52.443","textData":"123d=="}
+I0801 22:23:53.820236   29444 main.go:284] Added TXT record result: {"statusCode":200,"id":8718494,"domainId":9754501,"domainName":"your.domain.name","nodeName":"","hostname":"your.domain.name","recordType":"TXT","ttl":60,"state":true,"content":"your.domain.name. 60 IN TXT \"123d==\"","updatedOn":"2022-08-02T05:23:53.573","textData":"123d=="}
+I0801 22:23:53.820360   29444 main.go:144] Presented txt record cert-manager-dns01-tests.your.domain.name.
+I0801 22:23:58.673091   29444 main.go:196] TXT entry with content your.domain.name. 60 IN TXT "123d==" (key value 123d==)
+I0801 22:23:59.301171   29444 main.go:202] Deleted TXT record result: {"statusCode":200}
+I0801 22:23:59.302371   29444 main.go:196] TXT entry with content cert-manager-dns01-tests.your.domain.name. 60 IN TXT "123d==" (key value 123d==)
+I0801 22:23:59.921555   29444 main.go:202] Deleted TXT record result: {"statusCode":200}
+I0801 22:23:59.921671   29444 main.go:196] TXT entry with content your.domain.name. 120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 3600 900 604800 300 (key value 123d==)
+I0801 22:24:12.817203   29444 main.go:196] TXT entry with content your.domain.name. 120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 3600 900 604800 300 (key value 123d==)
+=== RUN   TestRunsSuite/Extended
+=== RUN   TestRunsSuite/Extended/DeletingOneRecordRetainsOthers
+    suite.go:73: skipping test as strict mode is disabled, see: https://github.com/cert-manager/cert-manager/pull/1354
+--- PASS: TestRunsSuite (165.87s)
+    --- PASS: TestRunsSuite/Basic (58.42s)
+        --- PASS: TestRunsSuite/Basic/PresentRecord (58.42s)
+    --- PASS: TestRunsSuite/Extended (0.00s)
+        --- SKIP: TestRunsSuite/Extended/DeletingOneRecordRetainsOthers (0.00s)
 PASS
-ok  	github.com/cert-manager/cert-manager-webhook-dynu	24.867s
+ok      github.com/Dopingus/cert-manager-webhook-dynu   166.121s
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ spec:
             config:
               secretName: dynu-secret # Adjust this in case you changed the secretName
               zoneName: <YOUR_DOMAIN> # Add the domain which you want to create certiciates for
-              apiUrl: https://api.dynu.com/v2
 ```
 
 ## Certificate

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ This is a webhook solver for [Dynu](https://www.dynu.com/).
 ## Installation
 
 ```bash
-helm install ./deploy/dynu-webhook
+helm repo add cert-manager-dynu-webhook \
+ https://anon-software.github.io/cert-manager-webhook-dynu
+helm repo update
+helm install cert-manager-dynu-webhook/dynu-webhook
 ```
 
 ## Certificate Issuer

--- a/README.md
+++ b/README.md
@@ -27,19 +27,20 @@ helm install ./deploy/dynu-webhook
     ```
 
     The `secretName` can also be changed in `deploy/dynu-webhook/values.yaml` in case you have to follow some convention. 
+    The secret must be created in the same namespace as the webhook.
 
 3. Create a certificate issuer:
 
-    ```yaml
-    apiVersion: cert-manager.io/v1alpha2
-    kind: ClusterIssuer
-    metadata:
-        name: letsencrypt-dynu-<YOUR_ISSUER_NAME>
-    spec:
-        acme:
-        # The ACME server URL
-        server: https://acme-v02.api.letsencrypt.org/directory              # Use this for prod
-        # server: https://acme-staging-v02.api.letsencrypt.org/directory    # Use this for staging/testing
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-dynu-<YOUR_ISSUER_NAME>
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory              # Use this for prod
+    # server: https://acme-staging-v02.api.letsencrypt.org/directory    # Use this for staging/testing
 
 
     # Email address used for ACME registration
@@ -59,14 +60,14 @@ helm install ./deploy/dynu-webhook
               secretName: dynu-secret # Adjust this in case you changed the secretName
               zoneName: <YOUR_DOMAIN> # Add the domain which you want to create certiciates for
               apiUrl: https://api.dynu.com/v2
-    ```
+```
 
 ## Certificate
 
 Issuing a certificate:
 
 ```yaml
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: <CERTIFICATE_NAME>  # Replace with a name of your choice

--- a/deploy/dynu-webhook/Chart.yaml
+++ b/deploy/dynu-webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for dynu webhook for cert-manager
 name: dynu-webhook
-version: 0.1.0
+version: 0.1.1

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -22,6 +21,7 @@ import (
 
 	"github.com/cert-manager/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1"
 	"github.com/cert-manager/cert-manager/pkg/acme/webhook/cmd"
+	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
 )
 
 const (
@@ -44,14 +44,10 @@ type DnsRecord struct {
 }
 
 type DomainResponse struct {
-	Domains []DomainRecord `json:"domains"`
-}
-
-type DomainRecord struct {
-	Id        int    `json:"id"`
-	Name      string `json:"name"`
-	Ttl       int    `json:"ttl"`
-	UpdatedOn string `json:"updatedOn"`
+	Id         int    `json:"id"`
+	DomainName string `json:"domainName"`
+	Hostname   string `json:"hostname"`
+	Node       string `json:"node"`
 }
 
 var GroupName = os.Getenv("GROUP_NAME")
@@ -61,26 +57,60 @@ func main() {
 		panic("GROUP_NAME must be specified")
 	}
 
+	// This will register our custom DNS provider with the webhook serving
+	// library, making it available as an API under the provided GroupName.
+	// You can register multiple DNS provider implementations with a single
+	// webhook, where the Name() method will be used to disambiguate between
+	// the different implementations.
 	cmd.RunWebhookServer(GroupName,
 		&dynuDNSProviderSolver{},
 	)
 }
 
+// customDNSProviderSolver implements the provider-specific logic needed to
+// 'present' an ACME challenge TXT record for your own DNS provider.
+// To do so, it must implement the `github.com/jetstack/cert-manager/pkg/acme/webhook.Solver`
+// interface.
 type dynuDNSProviderSolver struct {
 	client *kubernetes.Clientset
 }
 
+// customDNSProviderConfig is a structure that is used to decode into when
+// solving a DNS01 challenge.
+// This information is provided by cert-manager, and may be a reference to
+// additional configuration that's needed to solve the challenge for this
+// particular certificate or issuer.
+// This typically includes references to Secret resources containing DNS
+// provider credentials, in cases where a 'multi-tenant' DNS solver is being
+// created.
+// If you do *not* require per-issuer or per-certificate configuration to be
+// provided to your webhook, you can skip decoding altogether in favour of
+// using CLI flags or similar to provide configuration.
+// You should not include sensitive information here. If credentials need to
+// be used by your provider here, you should reference a Kubernetes Secret
+// resource and fetch these credentials using a Kubernetes clientset.
 type dynuDNSProviderConfig struct {
+	// These fields will be set by users in the
+	// `issuer.spec.acme.dns01.providers.webhook.config` field.
 	SecretRef string `json:"secretName"`
-	ZoneName  string `json:"zoneName"`
 }
 
+// Name is used as the name for this DNS solver when referencing it on the ACME
+// Issuer resource.
+// This should be unique **within the group name**, i.e. you can have two
+// solvers configured with the same Name() **so long as they do not co-exist
+// within a single webhook deployment**.
 func (c *dynuDNSProviderSolver) Name() string {
 	return "dynu"
 }
 
+// Present is responsible for actually presenting the DNS record with the
+// DNS provider.
+// This method should tolerate being called multiple times with the same value.
+// cert-manager itself will later perform a self check to ensure that the
+// solver has correctly configured the DNS provider.
 func (c *dynuDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
-	klog.Infof("call function Present: namespace=%s, zone=%s, fqdn=%s", ch.ResourceNamespace, ch.ResolvedZone, ch.ResolvedFQDN)
+	klog.Infof("call function Present: ResourceNamespace=%s, ResolvedZone=%s, ResolvedFQDN=%s DNSName=%s", ch.ResourceNamespace, ch.ResolvedZone, ch.ResolvedFQDN, ch.DNSName)
 
 	cfg, err := loadConfig(ch.Config)
 	if err != nil {
@@ -98,19 +128,18 @@ func (c *dynuDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 	if err != nil {
 		return fmt.Errorf("unable to get api-key from secret %v", err)
 	}
-	zoneName := cfg.ZoneName
-	zoneId, err := getZoneIdFromZoneName(apiKey, zoneName)
+
+	domainId, recordName, err := getDomainIdFromFQDN(apiKey, ch.ResolvedFQDN)
 	if err != nil {
 		return err
 	}
 
-	recordName := determineRecordName(zoneName, ch.ResolvedFQDN)
 	baseRecordName := determineBaseRecordName(recordName)
 
 	// For requested record
-	addTxtRecord(apiKey, zoneId, recordName, ch)
+	addTxtRecord(apiKey, domainId, recordName, ch)
 	// For record name without _acme-challenge as well (DNS propagation is checked through this name)
-	addTxtRecord(apiKey, zoneId, baseRecordName, ch)
+	addTxtRecord(apiKey, domainId, baseRecordName, ch)
 
 	klog.Infof("Presented txt record %v", ch.ResolvedFQDN)
 
@@ -126,6 +155,12 @@ func determineBaseRecordName(recordName string) string {
 	}
 }
 
+// CleanUp should delete the relevant TXT record from the DNS provider console.
+// If multiple TXT records exist with the same record name (e.g.
+// _acme-challenge.example.com) then **only** the record with the same `key`
+// value provided on the ChallengeRequest should be cleaned up.
+// This is in order to facilitate multiple DNS validations for the same domain
+// concurrently.
 func (c *dynuDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) error {
 	cfg, err := loadConfig(ch.Config)
 	if err != nil {
@@ -141,13 +176,12 @@ func (c *dynuDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) error {
 		return fmt.Errorf("unable to get api-key from secret `%s/%s` ; %v", secretName, ch.ResourceNamespace, err)
 	}
 
-	zoneName := cfg.ZoneName
-	zoneId, err := getZoneIdFromZoneName(apiKey, zoneName)
+	domainId, _, err := getDomainIdFromFQDN(apiKey, ch.ResolvedFQDN)
 	if err != nil {
-		return fmt.Errorf("unable to retrieve zoneId for zoneName %s ; %v", zoneName, err)
+		return fmt.Errorf("unable to retrieve domainId for domain name %s ; %v", ch.DNSName, err)
 	}
 
-	dnsRecords, err := getRecordsForDomain(apiKey, zoneId)
+	dnsRecords, err := getRecordsForDomain(apiKey, domainId)
 	if err != nil {
 		return fmt.Errorf("unable to get DNS records %v", err)
 	}
@@ -161,7 +195,7 @@ func (c *dynuDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) error {
 	for i := len(dnsRecordsResponse.DnsRecords) - 1; i >= 0; i-- {
 		klog.Infof("TXT entry with content %s (key value %s)", dnsRecordsResponse.DnsRecords[i].Content, ch.Key)
 		if dnsRecordsResponse.DnsRecords[i].RecordType == "TXT" && dnsRecordsResponse.DnsRecords[i].TextData == ch.Key {
-			deleteResponse, err := deleteTxtRecord(apiKey, zoneId, dnsRecordsResponse.DnsRecords[i].Id)
+			deleteResponse, err := deleteTxtRecord(apiKey, domainId, dnsRecordsResponse.DnsRecords[i].Id)
 			if err != nil {
 				klog.Error(err)
 			}
@@ -172,6 +206,15 @@ func (c *dynuDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) error {
 	return nil
 }
 
+// Initialize will be called when the webhook first starts.
+// This method can be used to instantiate the webhook, i.e. initialising
+// connections or warming up caches.
+// Typically, the kubeClientConfig parameter is used to build a Kubernetes
+// client that can be used to fetch resources from the Kubernetes API, e.g.
+// Secret resources containing credentials used to authenticate with DNS
+// provider accounts.
+// The stopCh can be used to handle early termination of the webhook, in cases
+// where a SIGTERM or similar signal is sent to the webhook process.
 func (c *dynuDNSProviderSolver) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
 	cl, err := kubernetes.NewForConfig(kubeClientConfig)
 	klog.V(6).Infof("Input variable stopCh is %d length", len(stopCh))
@@ -184,6 +227,8 @@ func (c *dynuDNSProviderSolver) Initialize(kubeClientConfig *rest.Config, stopCh
 	return nil
 }
 
+// loadConfig is a small helper function that decodes JSON configuration into
+// the typed config struct.
 func loadConfig(cfgJSON *extapi.JSON) (dynuDNSProviderConfig, error) {
 	cfg := dynuDNSProviderConfig{}
 	// handle the 'base case' where no configuration has been provided
@@ -197,36 +242,20 @@ func loadConfig(cfgJSON *extapi.JSON) (dynuDNSProviderConfig, error) {
 	return cfg, nil
 }
 
-func determineRecordName(zoneName string, fqdn string) string {
-	r := regexp.MustCompile("(.+)\\." + zoneName + "\\.")
-	name := r.FindStringSubmatch(fqdn)
-	if len(name) != 2 {
-		klog.Errorf("splitting domain name %s failed!", fqdn)
-		return ""
-	}
-	return name[1]
-}
-
-func getZoneIdFromZoneName(apiKey string, zoneName string) (string, error) {
-	url := apiUrl + "/dns"
+func getDomainIdFromFQDN(apiKey string, ResolvedFQDN string) (string, string, error) {
+	hostname := util.UnFqdn(ResolvedFQDN)
+	url := apiUrl + "/dns/getroot/" + hostname
 	response, err := callDnsApi(url, "GET", nil, apiKey)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	domainResponse := DomainResponse{}
 	readErr := json.Unmarshal(response, &domainResponse)
 	if readErr != nil {
-		return "", readErr
+		return "", "", readErr
 	}
-
-	for _, domain := range domainResponse.Domains {
-		if domain.Name == zoneName {
-			return fmt.Sprint(domain.Id), nil
-		}
-	}
-
-	return "", fmt.Errorf(`zone "%s" could not be found in managed domains`, zoneName)
+	return fmt.Sprint(domainResponse.Id), domainResponse.Node, nil
 }
 
 func stringFromSecretData(secretData *map[string][]byte, key string) (string, error) {
@@ -237,7 +266,7 @@ func stringFromSecretData(secretData *map[string][]byte, key string) (string, er
 	return string(data), nil
 }
 
-func addTxtRecord(apiKey string, zoneId string, recordName string, ch *v1alpha1.ChallengeRequest) {
+func addTxtRecord(apiKey string, domainId string, recordName string, ch *v1alpha1.ChallengeRequest) {
 	requestbody := map[string]string{
 		"nodeName":   recordName,
 		"recordType": "TXT",
@@ -246,7 +275,7 @@ func addTxtRecord(apiKey string, zoneId string, recordName string, ch *v1alpha1.
 		"state":      "true",
 		"textData":   ch.Key}
 	jsonBody, _ := json.Marshal(requestbody)
-	url := apiUrl + "/dns/" + zoneId + "/record"
+	url := apiUrl + "/dns/" + domainId + "/record"
 	response, err := callDnsApi(url, "POST", bytes.NewBuffer(jsonBody), apiKey)
 
 	if err != nil {
@@ -255,15 +284,15 @@ func addTxtRecord(apiKey string, zoneId string, recordName string, ch *v1alpha1.
 	klog.Infof("Added TXT record result: %s", string(response))
 }
 
-func getRecordsForDomain(apiKey string, zoneId string) ([]byte, error) {
-	url := apiUrl + "/dns/" + zoneId + "/record"
+func getRecordsForDomain(apiKey string, domainId string) ([]byte, error) {
+	url := apiUrl + "/dns/" + domainId + "/record"
 	response, err := callDnsApi(url, "GET", nil, apiKey)
 
 	return response, err
 }
 
-func deleteTxtRecord(apiKey string, zoneId string, recordId int) (string, error) {
-	url := apiUrl + "/dns/" + zoneId + "/record/" + fmt.Sprint(recordId)
+func deleteTxtRecord(apiKey string, domainId string, recordId int) (string, error) {
+	url := apiUrl + "/dns/" + domainId + "/record/" + fmt.Sprint(recordId)
 	response, err := callDnsApi(url, "DELETE", nil, apiKey)
 
 	return string(response), err

--- a/main_test.go
+++ b/main_test.go
@@ -38,7 +38,6 @@ func TestRunsSuite(t *testing.T) {
 		//dns.SetDNSServer("ns4.dynu.com:53"),
 		dns.SetManifestPath("testdata/dynu/dynu-secret.yaml"),
 		dns.SetConfig(&extapi.JSON{ Raw: d, }),
-
 	)
 
 	//need to uncomment and  RunConformance delete runBasic and runExtended once https://github.com/cert-manager/cert-manager/pull/4835 is merged

--- a/testdata/dynu/config.json
+++ b/testdata/dynu/config.json
@@ -1,5 +1,4 @@
 {
-    "secretName": "dynu-secret",
-	"zoneName": "yourdomain.managedby.dynu",
-	"apiUrl": "https://api.dynu.com/v2"
+	"secretName": "dynu-secret",
+	"zoneName": "yourdomain.managedby.dynu"
 }

--- a/testdata/dynu/config.json
+++ b/testdata/dynu/config.json
@@ -1,4 +1,3 @@
 {
-	"secretName": "dynu-secret",
-	"zoneName": "yourdomain.managedby.dynu"
+	"secretName": "dynu-secret"
 }


### PR DESCRIPTION
First, let's make the Helm chart more accessible. Downloading the complete source repository in order to just install the chart is cumbersome. We can do better by converting the git repository itself into helm chart repository with help of a GitHub action. This action converts GitHub pages of the repository into the chart repository.

Before merging this pull request one must set up GitHub Pages and for that a new branch traditionally called "gh-pages" is required. Since this branch should not have any source files it can be "orphaned". Note that Git automatically stages the current files after creating an orphaned branch that you want to unstage.

```
git checkout --orphan gh-pages
git rm --cached -r .
```
Create README.md file as the "home page" of the Helm repository:
```
## Usage

[Helm](https://helm.sh) must be installed to use the charts.  Please refer to
Helm's [documentation](https://helm.sh/docs) to get started.

Once Helm has been set up correctly, add the repo as follows:

  helm repo add cert-manager-webhook-dynu https://dopingus.github.io/cert-manager-webhook-dynu

If you had already added this repo earlier, run `helm repo update` to retrieve
the latest versions of the packages.  You can then run `helm search repo
cert-manager-webhook-dynu` to see the charts.

To install the dynu-webhook chart:

    helm install dynu-webhook cert-manager-webhook-dynu/dynu-webhook

To uninstall the chart:

    helm delete dynu-webhook
```
With a couple of more commands complete the new branch and return to master:
```
git add README.md
git commit -m "Initial commit"
git push --set-upstream origin gh-pages
git checkout -f master
```
GitHub will present the README.md as HTML when you access the "home page" at https://dopingus.github.io/cert-manager-webhook-dynu/, but more importantly the Helm chart will be accessible there too once the pull request is merged.

Next, I do not think there is a good reason to make the API URL configurable. It is just a burden to the user to enter it into the configuration and in the event Dynu changes it they will likely make an incompatible change in the API as well rendering the current code unusable.

Finally, by leveraging a different API, we can drop the "zone" from the configuration leaving API secret specification as the only item in the configuration.

README file has been changed to reflect the above. Also, some YAML indentation was incorrect and the test run log is now different.